### PR TITLE
Removed new listing notification

### DIFF
--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -34,7 +34,7 @@ class SpacesController < ApplicationController
     @space.user = @user
 
     if @space.save
-      redirect_to @user, notice: 'Listing was successfully created.'
+      redirect_to @user
     else
       render :new, status: :unprocessableentity
     end


### PR DESCRIPTION
Just removed the notification that said you've added a new listing when you've added one (was ugly and also defunct anyway as the new listing appears immediately)